### PR TITLE
Switch to MediaListCollection API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ In its current state, the only export the anime list. Custom lists are transcode
 
 ## Errors
 
-The only error that should be able to occur is going over the AniList API rate-limit. That kicks in when you make too many requests. The package makes 1 query per 50 entries in your list. People with more than 4500 entries in their lists will likely face currently unresolved issues when exporting. 
+The only error that should be able to occur is going over the AniList API rate-limit. That kicks in when you make too many requests. However, the package will only make 2 queries (a *User* and a *MediaListCollection*) even for lists reaching into the thousands in terms of entries. 
 
 Any other case in which the program panics and exits incorrectly, a bug report should be filed so the issue can be fixed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,53 @@ struct Args {
     file: PathBuf,
 }
 
+const COLLECTION_QUERY: &str ="
+query ($userName : String) {
+  MediaListCollection (userName: $userName, type:ANIME) {
+    user {
+      id
+    }
+    lists {
+      # name
+      entries {
+        id
+        status
+      	repeat
+      	progress
+      	customLists
+      	startedAt {
+	        year
+	        month
+	        day
+	      }
+	      completedAt {
+	        year
+	        month
+  	      day
+	      }
+      	createdAt
+      	updatedAt
+      	score
+      	notes
+      	media {
+	        idMal
+	        title {
+	          romaji
+	        }
+	        format
+	        episodes
+	      }
+	      priority
+      }
+      # isCustomList
+      # isSplitCompletedList
+      status
+    }
+    hasNextChunk
+  }
+}
+";
+
 const LIST_QUERY: &str = "
 query ($page : Int, $perPage : Int, $userName : String, $type: MediaType) {
   Page(page: $page, perPage: $perPage) {
@@ -79,6 +126,7 @@ query ($name : String) {
 enum QueryType {
     LIST,
     STATS,
+    COLLECTION,
 }
 
 async fn make_query(
@@ -88,6 +136,7 @@ async fn make_query(
     page: Option<i8>,
     qtype: QueryType,
 ) -> serde_json::Value {
+
     let list_query_json = json!({
         "query" : query,
         "variables" : {
@@ -103,6 +152,12 @@ async fn make_query(
             "name" : username
         }
     });
+    let collection_query_json = json!({
+        "query" : query,
+        "variables" : {
+            "userName" : username
+        }
+    });
 
     let resp = client
         .post("https://graphql.anilist.co/")
@@ -110,8 +165,10 @@ async fn make_query(
         .header("Accept", "application/json")
         .body(if qtype == QueryType::LIST {
             list_query_json.to_string()
-        } else {
+        } else if qtype == QueryType::STATS {
             stats_query_json.to_string()
+        } else {
+            collection_query_json.to_string()
         })
         .send()
         .await
@@ -158,32 +215,27 @@ async fn main() -> std::io::Result<()> {
     )?;
     writeln!(f, "\t</myinfo>")?;
 
-    let mut media_list: Vec<serde_json::Value> = Vec::new();
+    let mut media_list: Vec<xmlformat::AnimeEntry> = Vec::new();
     while {
         page_counter += 1;
-        let result = make_query(
-            LIST_QUERY,
-            &client,
-            &args.user,
-            Some(page_counter),
-            QueryType::LIST,
-        )
-        .await;
-        media_list.extend(
-            result["data"]["Page"]["mediaList"]
-                .as_array()
-                .expect("unexpected error occured while deserializing mediaList")
-                .to_owned(),
-        );
-        match result["data"]["Page"]["pageInfo"]["hasNextPage"].as_bool() {
+        let result = make_query(COLLECTION_QUERY, &client, &args.user, None, QueryType::COLLECTION).await;
+
+        let lists : Vec<xmlformat::AnimeList> = serde_json::from_value::<Vec<xmlformat::AnimeList>>(result["data"]["MediaListCollection"]["lists"].clone()).expect("unexpected error occured while parsing user lists");
+        for list in &lists {
+            match list.status {
+                None => (),
+                // only add entries from the status lists, entries from custom lists are going to
+                // be repeated in them either way.
+                Some(_) => media_list.extend(list.entries.clone())
+            };
+        };
+        match result["data"]["MediaListCollection"]["hasNextChunk"].as_bool() {
             Some(v) => v,
             None => false,
         }
     } {} // do-while
     for media_entry in media_list {
-        let media_entry_parsed: xmlformat::AnimeEntry = serde_json::from_value(media_entry)
-            .expect("unexpected error occured while deserializing anime list entry");
-        writeln!(f, "{}", xmlformat::xml_anime(media_entry_parsed))?;
+        writeln!(f, "{}", xmlformat::xml_anime(media_entry))?;
     }
     writeln!(f, "</myanimelist>")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ struct Args {
     file: PathBuf,
 }
 
-const COLLECTION_QUERY: &str ="
-query ($userName : String) {
-  MediaListCollection (userName: $userName, type:ANIME) {
+const LIST_QUERY: &str = "
+query ($userName : String, type: MediaType) {
+  MediaListCollection (userName: $userName, type: $type) {
     user {
       id
     }
@@ -64,47 +64,6 @@ query ($userName : String) {
 }
 ";
 
-const LIST_QUERY: &str = "
-query ($page : Int, $perPage : Int, $userName : String, $type: MediaType) {
-  Page(page: $page, perPage: $perPage) {
-    pageInfo {
-      total
-      currentPage
-      lastPage
-      hasNextPage
-      perPage
-    }
-    mediaList(userName: $userName, sort: SCORE_DESC, type: $type) {
-      status
-      repeat
-      progress
-      customLists
-      startedAt {
-        year
-        month
-        day
-      }
-      completedAt {
-        year
-        month
-        day
-      }
-      createdAt
-      updatedAt
-      score
-      notes
-      media {
-        idMal
-        title {
-          romaji
-        }
-        format
-        episodes
-      }
-    }
-  }
-}";
-
 const STATS_QUERY: &str = "
 query ($name : String) {
   User(name: $name) {
@@ -126,36 +85,25 @@ query ($name : String) {
 enum QueryType {
     LIST,
     STATS,
-    COLLECTION,
 }
 
 async fn make_query(
     query: &str,
     client: &reqwest::Client,
     username: &String,
-    page: Option<i8>,
     qtype: QueryType,
 ) -> serde_json::Value {
-
-    let list_query_json = json!({
-        "query" : query,
-        "variables" : {
-            "page" : page,
-            "perPage" : 50, // maximum per page
-            "userName" : username,
-            "type" : "ANIME"
-        }
-    });
     let stats_query_json = json!({
         "query" : query,
         "variables" : {
             "name" : username
         }
     });
-    let collection_query_json = json!({
+    let list_query_json = json!({
         "query" : query,
         "variables" : {
-            "userName" : username
+            "userName" : username,
+            "type" : "ANIME"
         }
     });
 
@@ -165,10 +113,8 @@ async fn make_query(
         .header("Accept", "application/json")
         .body(if qtype == QueryType::LIST {
             list_query_json.to_string()
-        } else if qtype == QueryType::STATS {
-            stats_query_json.to_string()
         } else {
-            collection_query_json.to_string()
+            stats_query_json.to_string()
         })
         .send()
         .await
@@ -183,7 +129,6 @@ async fn main() -> std::io::Result<()> {
     let args = Args::parse();
     let client = Client::new();
 
-    let mut page_counter: i8 = 0;
     let path: &str = args.file.to_str().expect("couldn't decode file path");
     // create file / flush contents of an existing file
     #[allow(unused_assignments)]
@@ -194,7 +139,7 @@ async fn main() -> std::io::Result<()> {
         .open(path)?;
     f = OpenOptions::new().write(true).append(true).open(path)?;
 
-    let result = make_query(STATS_QUERY, &client, &args.user, None, QueryType::STATS).await;
+    let result = make_query(STATS_QUERY, &client, &args.user, QueryType::STATS).await;
     let user_statistics: xmlformat::UserStatistics =
         serde_json::from_value(result["data"]["User"]["statistics"]["anime"].to_owned())
             .expect("unexpected error occured while parsing in user statistics");
@@ -216,19 +161,22 @@ async fn main() -> std::io::Result<()> {
     writeln!(f, "\t</myinfo>")?;
 
     let mut media_list: Vec<xmlformat::AnimeEntry> = Vec::new();
+    // TODO: figure out what hasNextChunk means
     while {
-        page_counter += 1;
-        let result = make_query(COLLECTION_QUERY, &client, &args.user, None, QueryType::COLLECTION).await;
+        let result = make_query(LIST_QUERY, &client, &args.user, QueryType::LIST).await;
 
-        let lists : Vec<xmlformat::AnimeList> = serde_json::from_value::<Vec<xmlformat::AnimeList>>(result["data"]["MediaListCollection"]["lists"].clone()).expect("unexpected error occured while parsing user lists");
+        let lists: Vec<xmlformat::AnimeList> = serde_json::from_value::<Vec<xmlformat::AnimeList>>(
+            result["data"]["MediaListCollection"]["lists"].clone(),
+        )
+        .expect("unexpected error occured while parsing user lists");
         for list in &lists {
             match list.status {
                 None => (),
                 // only add entries from the status lists, entries from custom lists are going to
                 // be repeated in them either way.
-                Some(_) => media_list.extend(list.entries.clone())
+                Some(_) => media_list.extend(list.entries.clone()),
             };
-        };
+        }
         match result["data"]["MediaListCollection"]["hasNextChunk"].as_bool() {
             Some(v) => v,
             None => false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
 }
 
 const LIST_QUERY: &str = "
-query ($userName : String, type: MediaType) {
+query ($userName : String, $type: MediaType) {
   MediaListCollection (userName: $userName, type: $type) {
     user {
       id

--- a/src/xmlformat.rs
+++ b/src/xmlformat.rs
@@ -74,7 +74,6 @@ pub struct AnimeList {
     pub status: Option<Status>,
 }
 
-
 #[derive(Deserialize)]
 #[allow(non_snake_case)]
 pub struct UserStatistics {

--- a/src/xmlformat.rs
+++ b/src/xmlformat.rs
@@ -2,7 +2,7 @@ use chrono::{Datelike, Local};
 use serde::Deserialize;
 
 #[derive(Deserialize, PartialEq, Copy, Clone)]
-enum Status {
+pub enum Status {
     CURRENT,
     PLANNING,
     COMPLETED,
@@ -10,7 +10,7 @@ enum Status {
     PAUSED,
     REPEATING,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[allow(non_camel_case_types)]
 enum Format {
     TV,
@@ -26,21 +26,21 @@ enum Format {
     UNKNOWN, // UNKNOWN reserved because of Rust
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct Date {
     year: Option<u16>,
     month: Option<u8>,
     day: Option<u8>,
 }
-#[derive(Deserialize)]
-struct Title {
+#[derive(Deserialize, Clone, PartialEq)]
+pub struct Title {
     romaji: String,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[allow(non_snake_case)]
-struct Media {
+pub struct Media {
     idMal: Option<u64>,
-    title: Title,
+    pub title: Title,
     format: Option<Format>,
     episodes: Option<u64>,
 }
@@ -50,7 +50,7 @@ struct StatusEntry {
     count: u32,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[allow(non_snake_case)]
 pub struct AnimeEntry {
     status: Status,
@@ -61,8 +61,19 @@ pub struct AnimeEntry {
     completedAt: Date,
     score: f32,
     notes: Option<String>,
-    media: Media,
+    pub media: Media,
 }
+
+#[derive(Deserialize)]
+#[allow(non_snake_case)]
+pub struct AnimeList {
+    pub entries: Vec<AnimeEntry>,
+    // name: String,
+    // isCustomList: bool,
+    // isSplitCompletedList: bool,
+    pub status: Option<Status>,
+}
+
 
 #[derive(Deserialize)]
 #[allow(non_snake_case)]


### PR DESCRIPTION
_MediaList_ API calls are not the intended way to go about it, and the _MediaListCollection_ gives the complete list in one go.

Changes:
- src/main.rs
  - switched LIST_QUERY
  - deprecated pagination
  - slightly better logic for parsing entries into structs
- src/xmlformat.rs
  - added new derives for Clone and PartialEq for structs
  - made several structs and struct fields public
  - added deserializing struct _AnimeList_ corresponding to _MediaListGroup_ in the API