### PR TITLE
Merge testing branch to add features

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
-use std::{io, panic};
 use std::io::Write;
 use std::path::PathBuf;
+use std::{io, panic};
 
 use clap::{Parser, ValueEnum};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
@@ -31,7 +31,7 @@ struct Args {
     #[arg(short, long, help = "Use OAuth to export hidden entries")]
     oauth: bool,
     #[arg(long = "no-nsfw", action = clap::ArgAction::SetFalse)]
-    nsfw: bool
+    nsfw: bool,
 }
 
 const LIST_QUERY: &str = "
@@ -242,7 +242,8 @@ async fn main() -> std::io::Result<()> {
             panic!("OAuth token usage failed")
         }
     };
-    let user_statistics = pre_user_statistics.expect("an error has occured while parsing UserStatistics from API");
+    let user_statistics =
+        pre_user_statistics.expect("an error has occured while parsing UserStatistics from API");
 
     // header
     writeln!(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")?;
@@ -309,16 +310,26 @@ async fn main() -> std::io::Result<()> {
     for media_entry in status_media_list {
         if !(args.nsfw == false && media_entry.media.isAdult == true) {
             match args.list_type {
-                ListType::Anime => writeln!(f, "{}", xmlformat::xml_anime(media_entry, args.update))?,
-                ListType::Manga => writeln!(f, "{}", xmlformat::xml_manga(media_entry, args.update))?,
+                ListType::Anime => {
+                    writeln!(f, "{}", xmlformat::xml_anime(media_entry, args.update))?
+                }
+                ListType::Manga => {
+                    writeln!(f, "{}", xmlformat::xml_manga(media_entry, args.update))?
+                }
             }
         }
     }
     for media_entry in custom_media_list {
-        if media_entry.hiddenFromStatusLists && !(args.nsfw == false && media_entry.media.isAdult == true) {
+        if media_entry.hiddenFromStatusLists
+            && !(args.nsfw == false && media_entry.media.isAdult == true)
+        {
             match args.list_type {
-                ListType::Anime => writeln!(f, "{}", xmlformat::xml_anime(media_entry, args.update))?,
-                ListType::Manga => writeln!(f, "{}", xmlformat::xml_manga(media_entry, args.update))?,
+                ListType::Anime => {
+                    writeln!(f, "{}", xmlformat::xml_anime(media_entry, args.update))?
+                }
+                ListType::Manga => {
+                    writeln!(f, "{}", xmlformat::xml_manga(media_entry, args.update))?
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ query ($userName : String, $type: MediaType) {
       	score
       	notes
       	media {
-	        idMal
+            idMal
             isAdult
 	        title {
 	          romaji
@@ -305,12 +305,6 @@ async fn main() -> std::io::Result<()> {
             status_media_list.extend(list.entries.clone())
         }
     }
-    // Truth table:
-    // nsfw | isAdult | result
-    // 1    | 0       | 1
-    // 1    | 0       | 1
-    // 0    | 1       | 0
-    // 0    | 0       | 1
 
     for media_entry in status_media_list {
         if !(args.nsfw == false && media_entry.media.isAdult == true) {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,0 +1,3 @@
+pub fn gen_url(id: &str) -> String {
+    format!("https://anilist.co/api/v2/oauth/authorize?client_id={}&response_type=token", id)
+}

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,3 +1,6 @@
 pub fn gen_url(id: &str) -> String {
-    format!("https://anilist.co/api/v2/oauth/authorize?client_id={}&response_type=token", id)
+    format!(
+        "https://anilist.co/api/v2/oauth/authorize?client_id={}&response_type=token",
+        id
+    )
 }

--- a/src/xmlformat.rs
+++ b/src/xmlformat.rs
@@ -40,6 +40,7 @@ pub struct Title {
 #[allow(non_snake_case)]
 pub struct Media {
     idMal: Option<u64>,
+    pub isAdult: bool,
     pub title: Title,
     format: Option<Format>,
     episodes: Option<u64>,


### PR DESCRIPTION
Added the following changes in this PR:
- support for exporting private entries with OAuth (new file: `src/oauth.rs`)
- support for disabling the default export of adult entries
- slight rework of CLI arguments
- added export of custom media list entries hidden from status lists in for manga